### PR TITLE
Adds function to create refsets, bump major version number because path syntax was removed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor-json-graph",
-  "version": "1.1.5",
+  "version": "2.0.0",
   "description": "A set of factory functions for creating JSON Graph values.",
   "main": "src/index.js",
   "scripts": {
@@ -22,5 +22,5 @@
     "JSON Graph"
   ],
   "homepage": "https://github.com/Netflix/falcor-json-graph",
-  "dependencies": { }
+  "dependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ function sentinel(type, value, props) {
 }
 
 module.exports = {
+    sentinel: sentinel,
     ref: function ref(path, props) {
         return sentinel("ref", path, props);
     },
@@ -26,6 +27,9 @@ module.exports = {
     },
     error: function error(errorValue, props) {
         return sentinel("error", errorValue, props);
+    },
+    refset: function refset(path, props) {
+        return sentinel("refset", path, props);
     },
     pathValue: function pathValue(path, value) {
         return { path: path, value: value };


### PR DESCRIPTION
@jhusain we need this for new refsets work. The current falcor unit tests are on an old version and were written expecting that `falcor-json-graph` understood path syntax. Will need to do some follow-up work on those to either use Array syntax or pre-convert the path syntax before calling these methods.