### PR TITLE
Simplified sentinel helper function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,9 @@
 function sentinel(type, value, props) {
-    var copy = Object.create(null);
-    if (props != null) {
-        for(var key in props) {
-            copy[key] = props[key];
-        }
-
-        copy["$type"] = type;
-        copy.value = value;
-        return copy;
+    var copy = { $type: type, value: value };
+    for(var key in props) {
+        copy[key] = props[key];
     }
-    else {
-        return { $type: type, value: value };
-    }
+    return copy;
 }
 
 module.exports = {


### PR DESCRIPTION
1) Removed duplicate logic that set $type and value in two places.  This led to a simpler syntax with one return statement.
2) Removed the null check on props because it was unnecessary.  If props is null or undefined, the for loop will not be entered.